### PR TITLE
Revert "techpack: video: msm: vidc: disable decode batching feature"

### DIFF
--- a/techpack/video/msm/vidc/msm_vidc_platform.c
+++ b/techpack/video/msm/vidc/msm_vidc_platform.c
@@ -991,7 +991,7 @@ static struct msm_vidc_common_data lito_common_data_v0[] = {
 	},
 	{
 		.key = "qcom,decode-batching",
-		.value = 0,
+		.value = 1,
 	},
 	{
 		.key = "qcom,batch-timeout",
@@ -1077,7 +1077,7 @@ static struct msm_vidc_common_data lito_common_data_v1[] = {
 	},
 	{
 		.key = "qcom,decode-batching",
-		.value = 0,
+		.value = 1,
 	},
 	{
 		.key = "qcom,batch-timeout",
@@ -1160,7 +1160,7 @@ static struct msm_vidc_common_data lagoon_common_data_v0[] = {
 	},
 	{
 		.key = "qcom,decode-batching",
-		.value = 0,
+		.value = 1,
 	},
 	{
 		.key = "qcom,batch-timeout",
@@ -1246,7 +1246,7 @@ static struct msm_vidc_common_data lagoon_common_data_v1[] = {
 	},
 	{
 		.key = "qcom,decode-batching",
-		.value = 0,
+		.value = 1,
 	},
 	{
 		.key = "qcom,batch-timeout",
@@ -1339,7 +1339,7 @@ static struct msm_vidc_common_data kona_common_data[] = {
 	},
 	{
 		.key = "qcom,decode-batching",
-		.value = 0,
+		.value = 1,
 	},
 	{
 		.key = "qcom,batch-timeout",
@@ -1667,7 +1667,7 @@ static struct msm_vidc_common_data sm8150_common_data[] = {
 	},
 	{
 		.key = "qcom,decode-batching",
-		.value = 0,
+		.value = 1,
 	},
 	{
 		.key = "qcom,batch-timeout",


### PR DESCRIPTION
This reverts commit 59e42e116d2b5039845c7c73fda3786b2d2c63cb.

Reason for revert: We do not use C2 for video, this is useful for OMX

Change-Id: I2bdd191313300e86a108087a1854252dc457f54c